### PR TITLE
Fix Cove Heroes

### DIFF
--- a/docs/heroes.md
+++ b/docs/heroes.md
@@ -432,8 +432,8 @@ You might also want to see [towns](towns.md).
 | :--- | :--- | :---: | :---: | :---: | :---: | :--- | :--- | :--- |
 | Casmetra | :magic: Navigator | 2 | 0 | 1 | 2 | 🚧 | Wisdom | Cove |
 | Cassiopeia | :might: Captain | 3 | 0 | 2 | 1 | Oceanids | Tactics | Cove |
-| Jeremy | :might: Captain | 3 | 0 | 2 | 1 | 🚧 | Offense | Cove |
-| Zilare | :magic: Navigator | 2 | 1 | 1 | 1 | Forgetfulness | Influence | Cove |
+| Jeremy | :might: Captain | 3 | 0 | 2 | 1 | Cannon | Offense | Cove |
+| Zilare | :magic: Navigator | 2 | 1 | 1 | 1 | Forgetfulness | Interference | Cove |
 
 
 ### Casmetra


### PR DESCRIPTION
A small fix.

BTW, I think specialty and starting ability columns should be swapped. In the game's hero cards, starting ability is on the left, while specialty is on the right. In here, it's the other way around, which is slightly confusing.