### PR TITLE
Fixed typo in Archery skill Notes

### DIFF
--- a/docs/abilities/archery.md
+++ b/docs/abilities/archery.md
@@ -22,7 +22,7 @@ ___
 
 ## Notes
 
-- This ability is active during each ranged attack of the Combat round, which means that it applies to both attacks of [Elves](../units/elves.md) and [Sharpshooters](../units/sharpshooters.md).
+- This ability is active during each ranged attack of the Combat round, which means that it applies to both attacks of [Elves](../units/elves.md) and [Marksmen](../units/marksmen.md).
 
 
 ## Comes With

--- a/translations/archery.md/archery.md.pot
+++ b/translations/archery.md/archery.md.pot
@@ -579,7 +579,7 @@ msgstr ""
 msgid ""
 "This ability is active during each ranged attack of the Combat round, which "
 "means that it applies to both attacks of [Elves](../units/elves.md) and "
-"[Sharpshooters](../units/sharpshooters.md)."
+"[Marksmen](../units/marksmen.md)."
 msgstr ""
 
 #. type: Bullet: '- '

--- a/translations/archery.md/es.po
+++ b/translations/archery.md/es.po
@@ -576,8 +576,8 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: docs/abilities/archery.md
-msgid "This ability is active during each ranged attack of the Combat round, which means that it applies to both attacks of [Elves](../units/elves.md) and [Sharpshooters](../units/sharpshooters.md)."
-msgstr "Esta habilidad se activa durante cada ataque a distancia de la ronda de Combate, lo que significa que se aplica a ambos ataques de [Elfos](../units/elves.md) y [Tiradores Certeros](../units/sharpshooters.md)."
+msgid "This ability is active during each ranged attack of the Combat round, which means that it applies to both attacks of [Elves](../units/elves.md) and [Marksmen](../units/marksmen.md)."
+msgstr "Esta habilidad se activa durante cada ataque a distancia de la ronda de Combate, lo que significa que se aplica a ambos ataques de [Elfos](../units/elves.md) y [Ballesteros](../units/marksmen.md)."
 
 #. type: Bullet: '- '
 #: docs/abilities/archery.md docs/abilities/armorer.md

--- a/translations/archery.md/pl.po
+++ b/translations/archery.md/pl.po
@@ -575,7 +575,7 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: docs/abilities/archery.md
-msgid "This ability is active during each ranged attack of the Combat round, which means that it applies to both attacks of [Elves](../units/elves.md) and [Sharpshooters](../units/sharpshooters.md)."
+msgid "This ability is active during each ranged attack of the Combat round, which means that it applies to both attacks of [Elves](../units/elves.md) and [Marksmen](../units/marksmen.md)."
 msgstr ""
 
 #. type: Bullet: '- '


### PR DESCRIPTION
Fixed typo in Archery skill Notes: replaced "Sharpshooters" with "Marksmen"